### PR TITLE
feat: add two-step verification

### DIFF
--- a/src/api/usersApi.ts
+++ b/src/api/usersApi.ts
@@ -19,6 +19,7 @@ export class UserService {
           code: 200,
           message: '登录成功',
           data: {
+            mfa: true,
             accessToken:
               'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6IkpvaG4gU25vdyIsImlhdCI6MTcwNjg2NTYwMCwiZXhwIjoxNzA2OTUyMDAwfQ.8f9D4kJ2m3XlH5Q0y6Z1r2Y3n4X5pL6q8K9v2W3n4X5'
           }
@@ -27,6 +28,30 @@ export class UserService {
         resolve({
           code: 401,
           message: '用户名或密码错误',
+          data: null
+        })
+      }
+    })
+  }
+
+  // 模拟登录接口
+  static twoStep(options: { body: string }): Promise<BaseResult> {
+    return new Promise((resolve) => {
+      const { twoStep } = JSON.parse(options.body)
+
+      if (twoStep === '666666') {
+        resolve({
+          code: 200,
+          message: '登录成功',
+          data: {
+            accessToken:
+              'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6IkpvaG4gU25vdyIsImlhdCI6MTcwNjg2NTYwMCwiZXhwIjoxNzA2OTUyMDAwfQ.8f9D4kJ2m3XlH5Q0y6Z1r2Y3n4X5pL6q8K9v2W3n4X5'
+          }
+        })
+      } else {
+        resolve({
+          code: 401,
+          message: '动态密码错误',
           data: null
         })
       }

--- a/src/config/core/base-config.ts
+++ b/src/config/core/base-config.ts
@@ -9,7 +9,8 @@ export const createBaseConfig = (): SystemConfig => ({
     name: 'Art Design Pro',
     login: {
       username: 'admin',
-      password: '123456'
+      password: '123456',
+      twoStep: []
     }
   },
   // Element Plus 主题

--- a/src/config/types/index.ts
+++ b/src/config/types/index.ts
@@ -23,7 +23,7 @@ export interface SystemConfig {
   elementPlusTheme: { primary: string }
   systemInfo: {
     name: string
-    login: { username: string; password: string }
+    login: { username: string; password: string; twoStep: string[] }
   }
   systemThemeStyles: SystemThemeTypes
   settingThemeList: ThemeSetting[]

--- a/src/language/locales/en.json
+++ b/src/language/locales/en.json
@@ -116,7 +116,8 @@
     "placeholder": [
       "Please enter your account",
       "Please enter your password",
-      "Please slide to verify"
+      "Please slide to verify",
+      "Please enter your code"
     ],
     "sliderText": "Please slide to verify",
     "sliderSuccessText": "Verification successful",
@@ -125,6 +126,9 @@
     "btnText": "Login",
     "noAccount": "No account yet?",
     "register": "Register",
+    "twoSteps": "Two Step Verification",
+    "twoStepsTips": "We sent a verification code to your mobile. Enter the code from the mobile in the field below.(666666)",
+    "backLogin": "Back login",
     "success": {
       "title": "Login successful",
       "message": "Welcome back"

--- a/src/language/locales/zh.json
+++ b/src/language/locales/zh.json
@@ -106,7 +106,7 @@
     },
     "title": "欢迎回来",
     "subTitle": "输入您的账号和密码登录",
-    "placeholder": ["请输入账号", "请输入密码", "请拖动滑块完成验证"],
+    "placeholder": ["请输入账号", "请输入密码", "请拖动滑块完成验证", "请输入动态密码"],
     "sliderText": "按住滑块拖动",
     "sliderSuccessText": "验证成功",
     "rememberPwd": "记住密码",
@@ -114,6 +114,9 @@
     "btnText": "登录",
     "noAccount": "还没有账号？",
     "register": "注册",
+    "twoSteps": "两步验证",
+    "twoStepsTips": "我们已向您的手机发送了一条验证码。请在下方的输入框中输入您手机上收到的验证码。(666666)",
+    "backLogin": "返回登录",
     "success": {
       "title": "登录成功",
       "message": "欢迎回来"

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -36,6 +36,7 @@ export type AppRouteRecordRaw = RouteRecordRaw & {
 
 /** 首页路径常量 */
 export const HOME_PAGE = '/dashboard/console'
+export const TWO_STEPS = '/two-steps'
 
 /** 静态路由配置 */
 const staticRoutes: AppRouteRecordRaw[] = [
@@ -71,6 +72,12 @@ const staticRoutes: AppRouteRecordRaw[] = [
     name: 'Login',
     component: () => import('@views/login/index.vue'),
     meta: { title: 'menus.login.title', isHideTab: true, setTheme: true }
+  },
+  {
+    path: RoutesAlias.twoSteps,
+    name: 'twoSteps',
+    component: () => import('@views/login/twoSteps.vue'),
+    meta: { title: 'menus.login.title', isHideTab: true, noLogin: true, setTheme: true }
   },
   {
     path: RoutesAlias.Register,

--- a/src/router/modules/routesAlias.ts
+++ b/src/router/modules/routesAlias.ts
@@ -2,6 +2,7 @@
 export enum RoutesAlias {
   Home = '/index/index', // 首页
   Login = '/login', // 登录
+  twoSteps = '/two-steps', // 登录
   Register = '/register', // 注册
   ForgetPassword = '/forget-password', // 忘记密码
   Exception403 = '/exception/403', // 403

--- a/src/views/login/index.scss
+++ b/src/views/login/index.scss
@@ -235,6 +235,22 @@
             text-decoration: none;
           }
         }
+
+        .towSetps {
+          display: flex;
+          flex: 1;
+          column-gap: 10px;
+          justify-content: space-between;
+
+          .el-input {
+            height: 50px;
+            font-size: 1.5rem;
+
+            :deep(.el-input__inner) {
+              text-align: center;
+            }
+          }
+        }
       }
     }
   }

--- a/src/views/login/twoSteps.vue
+++ b/src/views/login/twoSteps.vue
@@ -37,8 +37,8 @@
       </div>
       <div class="login-wrap">
         <div class="form">
-          <h3 class="title">{{ $t('login.title') }}</h3>
-          <p class="sub-title">{{ $t('login.subTitle') }}</p>
+          <h3 class="title">{{ $t('login.twoSteps') }}</h3>
+          <p class="sub-title">{{ $t('login.twoStepsTips') }}</p>
           <el-form
             ref="formRef"
             :model="formData"
@@ -46,47 +46,19 @@
             @keyup.enter="handleSubmit"
             style="margin-top: 25px"
           >
-            <el-form-item prop="username">
-              <el-input
-                :placeholder="$t('login.placeholder[0]')"
-                v-model.trim="formData.username"
-              />
-            </el-form-item>
-            <el-form-item prop="password">
-              <el-input
-                :placeholder="$t('login.placeholder[1]')"
-                v-model.trim="formData.password"
-                type="password"
-                radius="8px"
-                autocomplete="off"
-              />
-            </el-form-item>
-            <div class="drag-verify">
-              <div class="drag-verify-content" :class="{ error: !isPassing && isClickPass }">
-                <ArtDragVerify
-                  ref="dragVerify"
-                  v-model:value="isPassing"
-                  :width="width < 500 ? 328 : 438"
-                  :text="$t('login.sliderText')"
-                  textColor="var(--art-gray-800)"
-                  :successText="$t('login.sliderSuccessText')"
-                  :progressBarBg="getCssVariable('--el-color-primary')"
-                  background="var(--art-gray-200)"
-                  handlerBg="var(--art-main-bg-color)"
-                  @pass="onPass"
+            <el-form-item prop="twoStep" validate-on-rule-change="false">
+              <div class="towSetps">
+                <el-input
+                  v-for="(item, index) in 6"
+                  :key="index"
+                  v-model="formData.twoStep[index]"
+                  maxlength="1"
+                  ref="inputs"
+                  @input="handleInput(index)"
+                  @keydown.backspace="handleBackspace(index)"
                 />
               </div>
-              <p class="error-text" :class="{ 'show-error-text': !isPassing && isClickPass }">{{
-                $t('login.placeholder[2]')
-              }}</p>
-            </div>
-
-            <div class="forget-password">
-              <el-checkbox v-model="formData.rememberPassword">{{
-                $t('login.rememberPwd')
-              }}</el-checkbox>
-              <router-link to="/forget-password">{{ $t('login.forgetPwd') }}</router-link>
-            </div>
+            </el-form-item>
 
             <div style="margin-top: 30px">
               <el-button
@@ -102,8 +74,7 @@
 
             <div class="footer">
               <p>
-                {{ $t('login.noAccount') }}
-                <router-link to="/register">{{ $t('login.register') }}</router-link>
+                <router-link to="/login">{{ $t('login.backLogin') }}</router-link>
               </p>
             </div>
           </el-form>
@@ -117,9 +88,8 @@
   import AppConfig from '@/config'
   import { ElMessage, ElNotification } from 'element-plus'
   import { useUserStore } from '@/store/modules/user'
-  import { HOME_PAGE, TWO_STEPS } from '@/router'
+  import { HOME_PAGE } from '@/router'
   import { ApiStatus } from '@/utils/http/status'
-  import { getCssVariable } from '@/utils/colors'
   import { languageOptions } from '@/language'
   import { LanguageEnum, SystemThemeEnum } from '@/enums/appEnum'
   import { useI18n } from 'vue-i18n'
@@ -131,61 +101,76 @@
   const settingStore = useSettingStore()
   const { isDark, systemThemeType } = storeToRefs(settingStore)
 
-  const dragVerify = ref()
-
   const userStore = useUserStore()
   const router = useRouter()
-  const isPassing = ref(false)
-  const isClickPass = ref(false)
 
   const systemName = AppConfig.systemInfo.name
   const formRef = ref<FormInstance>()
   const formData = reactive({
-    username: AppConfig.systemInfo.login.username,
-    password: AppConfig.systemInfo.login.password,
-    rememberPassword: true
+    twoStep: AppConfig.systemInfo.login.twoStep
   })
 
   const rules = computed<FormRules>(() => ({
-    username: [{ required: true, message: t('login.placeholder[0]'), trigger: 'blur' }],
-    password: [{ required: true, message: t('login.placeholder[1]'), trigger: 'blur' }]
+    twoStep: [
+      {
+        required: true,
+        trigger: 'submit',
+        validator: (_rule, value: string[], callback) => {
+          if (!value || value.length !== 6 || value.some((v) => !v || v.trim() === '')) {
+            callback(new Error(t('login.placeholder[3]'))) // 比如 "請輸入完整驗證碼"
+          } else {
+            callback()
+          }
+        }
+      }
+    ]
   }))
 
   const loading = ref(false)
-  const { width } = useWindowSize()
 
-  const onPass = () => {}
+  const inputs = ref<(ComponentPublicInstance | null)[]>([])
+  const handleInput = (index: number) => {
+    nextTick(() => {
+      if (formData.twoStep[index] !== '' && index < inputs.value.length - 1) {
+        const nextInput = inputs.value[index + 1] as any
+        nextInput?.focus()
+      }
+      if (index === inputs.value.length - 1) {
+        handleSubmit()
+      }
+    })
+  }
+
+  const handleBackspace = (index: number) => {
+    nextTick(() => {
+      if (index > 0) {
+        setTimeout(() => {
+          const prevInput = inputs.value[index - 1] as any
+          prevInput.focus()
+          prevInput.select()
+        }, 0)
+      }
+    })
+  }
 
   const handleSubmit = async () => {
     if (!formRef.value) return
 
     await formRef.value.validate(async (valid) => {
       if (valid) {
-        if (!isPassing.value) {
-          isClickPass.value = true
-          return
-        }
-
         loading.value = true
 
         // 延时辅助函数
         const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
         try {
-          const res = await UserService.login({
+          const res = await UserService.twoStep({
             body: JSON.stringify({
-              username: formData.username,
-              password: formData.password
+              twoStep: formData.twoStep.join('')
             })
           })
 
           if (res.code === ApiStatus.success && res.data) {
-            if (res.data.mfa === true) {
-              // 跳转两步认证
-              router.push(TWO_STEPS)
-              return
-            }
-
             // 设置 token
             userStore.setToken(res.data.accessToken)
 
@@ -205,7 +190,6 @@
             router.push(HOME_PAGE)
           } else {
             ElMessage.error(res.message)
-            resetDragVerify()
           }
         } finally {
           await delay(1000)
@@ -213,11 +197,6 @@
         }
       }
     })
-  }
-
-  // 重置拖拽验证
-  const resetDragVerify = () => {
-    dragVerify.value.reset()
   }
 
   // 登录成功提示


### PR DESCRIPTION
This PR adds a new page for two-factor authentication (2FA) during login.

- Includes 6-digit verification code input
- Handles input focus and validation
- Displays error messages for incomplete or invalid codes

Let me know if any changes are needed.